### PR TITLE
chore: add PR label check workflow to enforce labeling requirements

### DIFF
--- a/.github/workflows/pr-label-check.yml
+++ b/.github/workflows/pr-label-check.yml
@@ -1,0 +1,43 @@
+name: PR Label Check
+
+on:
+    pull_request:
+        types: [opened, reopened, labeled, unlabeled, synchronize]
+
+jobs:
+    check-labels:
+        runs-on: ubuntu-latest
+        permissions:
+            pull-requests: read
+        steps:
+            - name: Check for required labels
+              uses: actions/github-script@v7
+              with:
+                  script: |
+                      const labels = context.payload.pull_request.labels.map(label => label.name);
+
+                      const validLabels = [
+                        'feature',
+                        'enhancement',
+                        'fix',
+                        'bugfix',
+                        'bug',
+                        'documentation',
+                        'docs',
+                        'chore',
+                        'maintenance',
+                        'dependencies',
+                        'deps'
+                      ];
+
+                      const hasValidLabel = labels.some(label => validLabels.includes(label));
+
+                      if (!hasValidLabel) {
+                        core.setFailed(
+                          `❌ This PR must have at least one label before merging.\n\n` +
+                          `Valid labels: ${validLabels.join(', ')}\n\n` +
+                          `Current labels: ${labels.length > 0 ? labels.join(', ') : 'none'}`
+                        );
+                      } else {
+                        console.log(`✅ PR has valid label(s): ${labels.filter(l => validLabels.includes(l)).join(', ')}`);
+                      }


### PR DESCRIPTION
A new workflow has been added to ensure that pull requests include at least one valid label before merging. This helps maintain consistency and clarity in the labeling of pull requests.