### PR TITLE
Refactor markdown escaping function for clarity and accuracy

### DIFF
--- a/src/discord_client.py
+++ b/src/discord_client.py
@@ -11,9 +11,11 @@ from discord_webhook import DiscordEmbed, DiscordWebhook
 logger = logging.getLogger(__name__)
 
 
-def _escape_markdown(text: str) -> str:
+def _escape_title_markdown(text: str) -> str:
     """
-    Escape Discord markdown characters to prevent formatting issues.
+    Escape markdown metacharacters that can alter a title's visible text.
+    This keeps titles looking raw in Discord while preventing emphasis, code,
+    and link-text parsing from changing what the user sees.
 
     Args:
         text: Text that may contain markdown characters
@@ -21,8 +23,7 @@ def _escape_markdown(text: str) -> str:
     Returns:
         Text with markdown characters escaped
     """
-    # Escape special markdown characters: * _ ~ ` | [ ] ( ) \
-    markdown_chars = r"([\*_~`\|\[\]\(\)\\])"
+    markdown_chars = r"([\\`*_~\[\]])"
     return re.sub(markdown_chars, r"\\\1", text)
 
 
@@ -420,8 +421,8 @@ class DiscordNotifier:
         title = item.get("title", "Unknown")
         rating_key = item.get("rating_key")
 
-        # Escape markdown characters in title to prevent formatting issues
-        safe_title = _escape_markdown(title)
+        # Escape only markdown characters that would alter the visible title
+        safe_title = _escape_title_markdown(title)
 
         # Create clickable link to Plex if URL and server ID are available
         if self.plex_url and self.plex_server_id and rating_key:

--- a/tests/test_discord_markdown.py
+++ b/tests/test_discord_markdown.py
@@ -2,90 +2,25 @@
 
 import pytest
 
-from src.discord_client import _escape_markdown
+from src.discord_client import _escape_title_markdown
 
 
-class TestEscapeMarkdown:
-    """Tests for _escape_markdown function."""
-
-    @pytest.mark.unit
-    def test_escape_asterisks(self):
-        """Test escaping asterisks."""
-        assert _escape_markdown("*bold*") == "\\*bold\\*"
-        assert _escape_markdown("**double**") == "\\*\\*double\\*\\*"
+class TestEscapeTitleMarkdown:
+    """Tests for _escape_title_markdown function."""
 
     @pytest.mark.unit
-    def test_escape_underscores(self):
-        """Test escaping underscores."""
-        assert _escape_markdown("_italic_") == "\\_italic\\_"
-        assert _escape_markdown("__double__") == "\\_\\_double\\_\\_"
+    def test_minimal_does_not_escape_parentheses(self):
+        """Test that parentheses remain unchanged."""
+        assert _escape_title_markdown("Movie (2025)") == "Movie (2025)"
 
     @pytest.mark.unit
-    def test_escape_brackets(self):
-        """Test escaping square brackets."""
-        assert _escape_markdown("[Title]") == "\\[Title\\]"
-        assert _escape_markdown("[Link](url)") == "\\[Link\\]\\(url\\)"
+    def test_minimal_escapes_emphasis(self):
+        """Test that emphasis characters are escaped."""
+        text = "Title *bold* _italic_ ~strike~ `code`"
+        expected = "Title \\*bold\\* \\_italic\\_ \\~strike\\~ \\`code\\`"
+        assert _escape_title_markdown(text) == expected
 
     @pytest.mark.unit
-    def test_escape_parentheses(self):
-        """Test escaping parentheses."""
-        assert _escape_markdown("(Year 2020)") == "\\(Year 2020\\)"
-
-    @pytest.mark.unit
-    def test_escape_backticks(self):
-        """Test escaping backticks."""
-        assert _escape_markdown("`code`") == "\\`code\\`"
-
-    @pytest.mark.unit
-    def test_escape_pipes(self):
-        """Test escaping pipes."""
-        assert _escape_markdown("A | B") == "A \\| B"
-
-    @pytest.mark.unit
-    def test_escape_tildes(self):
-        """Test escaping tildes."""
-        assert _escape_markdown("~~strikethrough~~") == "\\~\\~strikethrough\\~\\~"
-
-    @pytest.mark.unit
-    def test_escape_backslashes(self):
-        """Test escaping backslashes."""
-        assert _escape_markdown("path\\to\\file") == "path\\\\to\\\\file"
-
-    @pytest.mark.unit
-    def test_escape_mixed_characters(self):
-        """Test escaping multiple markdown characters."""
-        text = "Movie: [Title] (2020) - *Action* | _Drama_"
-        expected = "Movie: \\[Title\\] \\(2020\\) - \\*Action\\* \\| \\_Drama\\_"
-        assert _escape_markdown(text) == expected
-
-    @pytest.mark.unit
-    def test_no_escape_needed(self):
-        """Test that plain text is unchanged."""
-        assert _escape_markdown("Simple Title") == "Simple Title"
-        assert _escape_markdown("Movie Title 2020") == "Movie Title 2020"
-
-    @pytest.mark.unit
-    def test_empty_string(self):
-        """Test escaping empty string."""
-        assert _escape_markdown("") == ""
-
-    @pytest.mark.unit
-    def test_unicode_characters_preserved(self):
-        """Test that unicode characters are preserved."""
-        assert _escape_markdown("Movie 🎬") == "Movie 🎬"
-        assert _escape_markdown("Café ☕") == "Café ☕"
-
-    @pytest.mark.unit
-    def test_real_world_titles(self):
-        """Test escaping real-world problematic titles."""
-        # Title with brackets
-        assert _escape_markdown("Marvel's The Avengers [2012]") == "Marvel's The Avengers \\[2012\\]"
-
-        # Title with asterisk
-        assert (
-            _escape_markdown("Monty Python's Life of Brian *Best Comedy*")
-            == "Monty Python's Life of Brian \\*Best Comedy\\*"
-        )
-
-        # Title with parentheses
-        assert _escape_markdown("The Good (The Bad & The Ugly)") == "The Good \\(The Bad & The Ugly\\)"
+    def test_minimal_escapes_brackets(self):
+        """Test that link text brackets are escaped."""
+        assert _escape_title_markdown("Movie [Soon]") == "Movie \\[Soon\\]"


### PR DESCRIPTION
Rename and update the markdown escaping function to improve clarity and ensure it only escapes characters that alter a title's visible text. Adjust tests accordingly to reflect the new function name and behavior.