### PR TITLE
ci: update container-retention-policy to v3.0.0

### DIFF
--- a/.github/workflows/cleanup-registry.yml
+++ b/.github/workflows/cleanup-registry.yml
@@ -13,24 +13,22 @@ jobs:
     cleanup:
         runs-on: ubuntu-latest
         steps:
-            - name: Delete old container images
-              uses: snok/container-retention-policy@v3
+            - name: Delete old sha-tagged images
+              uses: snok/container-retention-policy@v3.0.0
               with:
+                  account: user
                   image-names: plex-releases-summary
-                  cut-off: 30 days ago UTC
-                  account-type: personal
-                  keep-at-least: 10
-                  untagged-only: false
-                  skip-tags: latest,develop,v*
+                  cut-off: 30d
+                  keep-n-most-recent: 10
+                  tag-selection: tagged
+                  image-tags: "sha-*"
                   token: ${{ secrets.GITHUB_TOKEN }}
-                  filter-tags: sha-*
 
             - name: Delete untagged images
-              uses: snok/container-retention-policy@v3
+              uses: snok/container-retention-policy@v3.0.0
               with:
+                  account: user
                   image-names: plex-releases-summary
-                  cut-off: 7 days ago UTC
-                  account-type: personal
-                  keep-at-least: 0
-                  untagged-only: true
+                  cut-off: 7d
+                  tag-selection: untagged
                   token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Update the container retention policy to version 3.0.0 and refine the cleanup steps for deleting old and untagged container images.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat: add X`, `fix: correct Y`)
- [x] Tests added or updated for new/changed behavior
- [x] All checks pass locally (`./scripts/test.sh`, `./scripts/format.sh`, `./scripts/typecheck.sh`)
- [x] Lockfiles regenerated if `requirements.txt` or `requirements-dev.txt` changed (`./scripts/compile-deps.sh`)
- [x] Docs updated if behavior or configuration changed

## Related issues

<!-- Closes #<issue_number> -->

