### PR TITLE
release: 2026-03-22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,7 +177,7 @@ jobs:
 
       - name: Extract metadata (tags, labels)
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,7 +165,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to GitHub Container Registry
         if: github.event_name != 'pull_request'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,7 +169,7 @@ jobs:
 
       - name: Log in to GitHub Container Registry
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,7 +136,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.34.1
+        uses: aquasecurity/trivy-action@0.35.0
         with:
           scan-type: fs
           scan-ref: .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,7 +194,7 @@ jobs:
 
       - name: Build and push Docker image
         id: build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Dockerfile

--- a/.github/workflows/cleanup-registry.yml
+++ b/.github/workflows/cleanup-registry.yml
@@ -14,12 +14,11 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Delete old container images
-              uses: snok/container-retention-policy@v2
+              uses: snok/container-retention-policy@v3
               with:
                   image-names: plex-releases-summary
                   cut-off: 30 days ago UTC
                   account-type: personal
-                  org-name: thomas-lg
                   keep-at-least: 10
                   untagged-only: false
                   skip-tags: latest,develop,v*
@@ -27,12 +26,11 @@ jobs:
                   filter-tags: sha-*
 
             - name: Delete untagged images
-              uses: snok/container-retention-policy@v2
+              uses: snok/container-retention-policy@v3
               with:
                   image-names: plex-releases-summary
                   cut-off: 7 days ago UTC
                   account-type: personal
-                  org-name: thomas-lg
                   keep-at-least: 0
                   untagged-only: true
                   token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cleanup-registry.yml
+++ b/.github/workflows/cleanup-registry.yml
@@ -13,24 +13,22 @@ jobs:
     cleanup:
         runs-on: ubuntu-latest
         steps:
-            - name: Delete old container images
-              uses: snok/container-retention-policy@v3
+            - name: Delete old sha-tagged images
+              uses: snok/container-retention-policy@v3.0.0
               with:
+                  account: user
                   image-names: plex-releases-summary
-                  cut-off: 30 days ago UTC
-                  account-type: personal
-                  keep-at-least: 10
-                  untagged-only: false
-                  skip-tags: latest,develop,v*
+                  cut-off: 30d
+                  keep-n-most-recent: 10
+                  tag-selection: tagged
+                  image-tags: "sha-*"
                   token: ${{ secrets.GITHUB_TOKEN }}
-                  filter-tags: sha-*
 
             - name: Delete untagged images
-              uses: snok/container-retention-policy@v3
+              uses: snok/container-retention-policy@v3.0.0
               with:
+                  account: user
                   image-names: plex-releases-summary
-                  cut-off: 7 days ago UTC
-                  account-type: personal
-                  keep-at-least: 0
-                  untagged-only: true
+                  cut-off: 7d
+                  tag-selection: untagged
                   token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -24,11 +24,10 @@ jobs:
 
         steps:
             - name: Create/Update Draft Release
-              uses: release-drafter/release-drafter@v6
+              uses: release-drafter/release-drafter@v7
               with:
                   config-name: release-drafter.yml
-              env:
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  token: ${{ secrets.GITHUB_TOKEN }}
 
     publish-release:
         runs-on: ubuntu-latest
@@ -39,9 +38,8 @@ jobs:
 
         steps:
             - name: Publish Release
-              uses: release-drafter/release-drafter@v6
+              uses: release-drafter/release-drafter@v7
               with:
                   config-name: release-drafter.yml
                   publish: ${{ github.event.inputs.dry_run == 'false' }}
-              env:
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-drafter-sync.yml
+++ b/.github/workflows/release-drafter-sync.yml
@@ -17,8 +17,7 @@ jobs:
 
         steps:
             - name: Update Draft Release
-              uses: release-drafter/release-drafter@v6
+              uses: release-drafter/release-drafter@v7
               with:
                   config-name: release-drafter.yml
-              env:
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Release branch for 2026-03-22, merging `develop` into `main`.

Changes since v1.3.3:
- ci: update container-retention-policy to v3.0.0 and refine cleanup steps (#103)
- fix: upgrade snok/container-retention-policy to v3 and remove org-name for personal account (#102)
- deps: bump release-drafter/release-drafter from 6 to 7 (#100)
- deps: bump aquasecurity/trivy-action in the github-actions group (#95)
- deps: bump docker/login-action from 3 to 4 (#96)
- deps: bump docker/metadata-action from 5 to 6 (#97)
- deps: bump docker/build-push-action from 6 to 7 (#98)
- deps: bump docker/setup-buildx-action from 3 to 4 (#99)

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] All checks pass locally

## Related issues

<!-- Closes #<issue_number> -->
